### PR TITLE
Switch to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Flake8 Annotator'
 author: 'Raphael Bialon'
 description: 'Annotate PRs with flake8 errors and warnings from Github checks output'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'check-circle'


### PR DESCRIPTION
Node 16 is EoL and has been deprecated for Actions: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Conveniently changing the version declared in action.yml is all that's needed for this action.

Closes: #11 